### PR TITLE
Wrap getCall() return type in a Promise

### DIFF
--- a/SendBirdCall.min.d.ts
+++ b/SendBirdCall.min.d.ts
@@ -36,7 +36,7 @@ export function setCallConnectionTimeout(timeout: number): void;
 export function handleWebhookData(data: WebhookData): void;
 export function addDirectCallSound(type: SoundType, url: string): Promise<boolean>;
 export function removeDirectCallSound(type: SoundType): boolean;
-export function getCall(callId: string): DirectCall;
+export function getCall(callId: string): Promise<DirectCall>;
 export function createRoom(params: RoomParams): Promise<Room>;
 export function getCachedRoomById(roomId: string): Room;
 export function fetchRoomById(roomId: string): Promise<Room>;


### PR DESCRIPTION
The `getCall()` function returns `Promise<DirectCall>` instead of `DirectCall` so I have updated the return type to reflect this which will resolve any related typescript errors which might occur when working with this package.